### PR TITLE
Update player out of bound check to use InvokeRepeating

### DIFF
--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -5,23 +5,14 @@
 
   void Start() {
     rb = GetComponent<UnityEngine.Rigidbody>();
-    StartCoroutine(CheckOutOfBounds());
+    InvokeRepeating("CheckOutOfBounds", 0f, 0.1f);
   }
 
-  public System.Collections.IEnumerator CheckOutOfBounds() {
-    // This checks the boundaries continuously. Eventually, we'll want to turn
-    // this off at certain times, like when the player doesn't have control over
-    // the character's movement.
-    while(true) {
-      if (transform.position.y < -6) {
-        // Reset the player's velocity and their position
-        rb.velocity = stationary;
-        transform.position = startPosition;
-      }
-
-      // The player bounds are pretty loosely defined, so it's fine to check on
-      // them a little less frequently.
-      yield return new UnityEngine.WaitForSeconds(0.1f);
+  public void CheckOutOfBounds() {
+    if (transform.position.y < -6) {
+      // Reset the player's velocity and their position
+      rb.velocity = stationary;
+      transform.position = startPosition;
     }
   }
 }


### PR DESCRIPTION
Resolves #10

---

I'm not 100% certain that coroutines are much slower than InvokeRepeating, but the arguments I've read so far make sense, so it seems likely.

With that said, this is just one additional coroutine, so the method I use for this might be negligible compared to other perf decisions. I'm mostly making this PR so that this repo has examples of each different option.

One thing to consider is the time when I want to turn off update checks. I just need to make sure that this works just as good as coroutines at being able to get disabled. Based on the public API of MonoBehaviours, I don't think we can cancel individual invocations like coroutines, so maybe this won't work for what I need.